### PR TITLE
Desacople del timer. Esto es parte de un rework de mayor tamaño pensando en el control de procesos posterior.

### DIFF
--- a/procedimiento.py
+++ b/procedimiento.py
@@ -26,9 +26,9 @@ class MACDentry(Worker):
 		"""
 		pass
 	def startWork(self):
-		self.lastCheck = db.getOlderServe(self.work)
+		self.timer.updateLastCheck(db.getOlderServe(self.work))
 		while True:
-			if self._internalTick() == True:
+			if self.timer.tick() == True:
 				pairs = db.servePairs(self.work, limit=100)
 				for pair in pairs:
 					df4h = db.getDataFrame(pair["symbol"], "4h")
@@ -51,7 +51,7 @@ class MACDentry(Worker):
 							print("Cant Check histogram, NoneValue")
 					else:
 						print("Dataframe empty")
-				self.lastCheck = db.getOlderServe(self.work)
+				self.timer.updateLastCheck(db.getOlderServe(self.work))
 
 if __name__ == "__main__":
 	##argv1 = USER/test

--- a/sistema.py
+++ b/sistema.py
@@ -11,40 +11,58 @@ import pandas_ta as ta
 
 workerTypes = ["dbWorker", "dbMiner", "dbCalculator"]
 db = DB()
+
+class Timer:
+	def __init__(self, updateTime = timedelta(hours=2)):
+		self.updateTime = updateTime
+		self.lastCheck = None
+	def updateLastCheck(self, newCheck):
+		self.lastCheck = newCheck
+	def tick(self):
+		now = datetime.now()
+		#print(f"lastCheck: {self.lastCheck}")
+		#print(f"now: {now}")
+		if self.lastCheck == None or now >= self.lastCheck + self.updateTime:
+			self.lastCheck = now
+			print(f"Timer.tick(): True | nextCheck: {self.lastCheck+self.updateTime}")
+			return True
+		else:
+			#print(f"Tick: False | nextCheck: {self.lastCheck + self.updateTime}")
+			return False
+	def externalTick(self, datetimeToTrack):
+		now = datetime.now()
+		if datetimeToTrack == None:
+			self.lastCheck = now
+			print(f"Timer.externalTick(): True | tracked: {datetimeToTrack}")
+			return True
+		elif now >= datetimeToTrack + self.updateTime:
+			self.lastCheck == now
+			print(f"Timer.externalTick(): True | tracked: {datetimeToTrack} | triggerHour: {datetimeToTrack+self.updateTime}")
+			return True
+		else:
+			return False
+
+
 class Worker:
 	def __init__(self, user, workType):
 		self.API = db.getAPI(user)
 		self.work = workType
 		self.client = Client(self.API[0], self.API[1])
-		self.updateTime = timedelta(hours=2)
-		self.lastCheck = None
-	def _internalTick(self):
-		#? No parece necesario implementar time awarenes. Los contenedores funcionan por defecto en UTC, asi que solo tengo que usar la conversion para
-		#? propositos de display.
-		now = datetime.now()
-		#print(f"lastCheck: {self.lastCheck}")
-		#print(f"now: {now}")
-		if self.lastCheck == None or now >= self.lastCheck + self.updateTime:
-			print(f"internalTick: True | nextCheck: {now+self.updateTime}")
-			self.lastCheck = now
-			return True
-		else:
-			#print(f"Tick: False | nextCheck: {self.lastCheck + self.updateTime}")
-			return False
+		self.timer = Timer()
 
 class dbWorker(Worker):
 	def __init__(self, user, workType):
 		super().__init__(user, workType)
 	def startWork(self):
 		while True:
-			if self._internalTick() == True:
+			if self.timer.tick() == True:
+				print("Starting Task. Updating Symbol Database.")
 				db.updateSymbols(self.client)
-				print(f"Next Check at: {self.lastCheck+self.updateTime}")
 
 class dbMiner(Worker):
 	def __init__(self, user, workType):
 		super().__init__(user, workType)
-		self.updateTime = timedelta(minutes=1)
+		self.timer.updateTime = timedelta(minutes=3)
 		self.pointsNeeded = 54
 		self.interval4h = timedelta(hours=4)
 		self.interval1d = timedelta(days=1)
@@ -71,30 +89,33 @@ class dbMiner(Worker):
 			##Si el conteo de la tabla y simbolo concreto da como vacio, intentar obtener los maximos puntos necesarios obteniendo la fecha de inicio (dateStartObj)
 			dateStartObj = dateEnd-(deltaInterval*self.pointsNeeded)
 			db.insertData(self.client, symbol, interval, str(dateStartObj), end = str(dateEnd), limit=self.pointsNeeded)
-			print(f"Tabla {interval}, vacia. Descargando datos completos desde {dateStartObj}")
+			print(f"------> {interval}, vacia. Descargando datos completos desde {dateStartObj}")
 		else:
 			##Si la tabla tiene datos ya, seguir capturando a partir de esa fecha.
-			print(f"Tabla {interval}, {symbol}, contiene datos. Comprobando tiempo {lastPoint[0]}")
+			print(f"------> {interval}, contiene datos. Comprobando tiempo {lastPoint[0]}")
 			if lastPoint[0] < dateEnd-deltaInterval:
-				print(f"Tabla {interval}, {symbol}, obteniendo ultimos puntos")
+				print(f"---------> {interval}, obteniendo ultimos puntos")
 				db.insertData(self.client,symbol, interval, str(lastPoint[0]+deltaInterval), end=str(dateEnd), limit=self.pointsNeeded)
+			else:
+				print(f"---------> {interval}, tabla actualizada.")
 	def startWork(self):
-		self.lastCheck = db.getOlderServe(self.work)
-		print("Starting Work")
-		print(f"lastCheck fetched from DB: {self.lastCheck}")
+		self.timer.updateLastCheck(db.getOlderServe(self.work))
 		while True:
-			if self._internalTick() == True:
-				pairs = db.servePairs(self.work, limit= 50)
+			if self.timer.tick() == True:
+				print("Starting Task, Mining Data.")
+				print(f"Timer.lastCheck fetched from DB: {self.timer.lastCheck}")
+				pairs = db.servePairs(self.work, limit= 100)
 				for pair in pairs:
-					print(f'Checking {pair["symbol"]} in db')
+					print(f"Checking {pair['symbol']}:")
+					print(f'---> Checking in db')
 					self._checkData(pair["symbol"], "4h")
 					self._checkData(pair["symbol"], "1d")
-				self.lastCheck = db.getOlderServe(self.work)
+				self.timer.updateLastCheck(db.getOlderServe(self.work))
 
 class dbCalculator(Worker):
 	def __init__(self, user, workType):
 		super().__init__(user, workType)
-		self.updateTime = timedelta(minutes=1)
+		self.timer.updateTime = timedelta(minutes=3)
 	def _calculate(self, symbol, interval):
 		print(f'Calculating data from {symbol} in db at interval {interval}')
 		df = db.getDataFrame(symbol, interval)
@@ -113,16 +134,16 @@ class dbCalculator(Worker):
 		else:
 			print("Dataframe Vacio, saltando")
 	def startWork(self):
-		self.lastCheck = db.getOlderServe(self.work)
+		self.timer.updateLastCheck(db.getOlderServe(self.work))
 		#print(self.lastCheck)
 		while True:
-			if self._internalTick() == True:
+			if self.timer.tick() == True:
 				pairs = db.servePairs(self.work, limit=100)
 				#print(pairs)
 				for pair in pairs:
 					self._calculate(pair["symbol"], "4h")
 					self._calculate(pair["symbol"], "1d")
-				self.lastCheck = db.getOlderServe(self.work)
+				self.timer.updateLastCheck(db.getOlderServe(self.work))
 
 if __name__ == "__main__":
 	##argv1 = USER/test


### PR DESCRIPTION
Desacople del timer. Es un paso para la creación de una capa de abstracción mas que gestione los workers y los monitores (funcion todavia no transferida desde legacy)